### PR TITLE
Vscode support

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -34,10 +34,18 @@ gem 'webpacker', '~> 4.0'
 
 gem 'bootsnap', '>= 1.4.2', require: false
 
+# `debase`, `ruby-debug-ide` and `solargraph` gems are dedicated
+# to support the following vscode plugins out of the box:
+# * https://github.com/castwide/vscode-solargraph
+# * https://github.com/rubyide/vscode-ruby.git
+# that are part of our base workflow.
 group :development do
+  gem 'debase'
   gem 'letter_opener'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'rack-mini-profiler', require: false
+  gem 'ruby-debug-ide'
+  gem 'solargraph'
   gem 'web-console', '>= 3.3.0'
 end
 

--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -59,8 +59,14 @@ For more information, please refer to respective repositories:
 * https://github.com/castwide/vscode-solargraph
 * https://github.com/rubyide/vscode-ruby.git
 
-Please, note that Solargraph already handles Rubocop's checks into the editor; do not install
-Rubocop-specific extensions or you'll get doubled messages.
+> Please, note that Solargraph already handles Rubocop's checks into the editor; do not install
+> Rubocop-specific extensions or you'll get doubled messages.
+
+Last but not least, you have both `.vscode/launch.json` and `.vscode/settings.json`. You can
+manage settings directly within VSCode UI in the "workspace" tab.
+
+The only defaults provided ATM are - almost - only about plugins matter of this paragraph. PRs to
+add sane defaults for other aspects are welcome.
 
 ## Setup on Heroku (delete if not applicable):
 

--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -44,6 +44,24 @@ Run the quality checks and the tests suite:
 
     $ rake
 
+### VSCode debug and intellisense
+
+If you're working with VSCode editor, you'd like to install dedicated extension running
+following commands into your terminal:
+
+```bash
+code --install-extension rebornix.ruby
+code --install-extension castwide.solargraph
+```
+
+For more information, please refer to respective repositories:
+
+* https://github.com/castwide/vscode-solargraph
+* https://github.com/rubyide/vscode-ruby.git
+
+Please, note that Solargraph already handles Rubocop's checks into the editor; do not install
+Rubocop-specific extensions or you'll get doubled messages.
+
 ## Setup on Heroku (delete if not applicable):
 
 ### Database

--- a/templates/dotfiles/.vscode/launch.json
+++ b/templates/dotfiles/.vscode/launch.json
@@ -1,0 +1,66 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Local File",
+      "type": "Ruby",
+      "request": "launch",
+      "cwd": "${workspaceRoot}",
+      "program": "${workspaceRoot}/main.rb"
+    },
+    {
+      "name": "Listen for rdebug-ide",
+      "type": "Ruby",
+      "request": "attach",
+      "cwd": "${workspaceRoot}",
+      "remoteHost": "127.0.0.1",
+      "remotePort": "1234",
+      "remoteWorkspaceRoot": "${workspaceRoot}"
+    },
+    {
+      "name": "Rails server",
+      "type": "Ruby",
+      "request": "launch",
+      "cwd": "${workspaceRoot}",
+      "program": "${workspaceRoot}/bin/rails",
+      "args": [
+        "server"
+      ]
+    },
+    {
+      "name": "RSpec - all",
+      "type": "Ruby",
+      "request": "launch",
+      "cwd": "${workspaceRoot}",
+      "program": "${workspaceRoot}/bin/rspec",
+      "args": [
+        "-I",
+        "${workspaceRoot}"
+      ]
+    },
+    {
+      "name": "RSpec - Current file",
+      "type": "Ruby",
+      "request": "launch",
+      "cwd": "${workspaceRoot}",
+      "program": "${workspaceRoot}/bin/rspec",
+      "args": [
+        "-I",
+        "${workspaceRoot}",
+        "${file}"
+      ]
+    },
+    {
+      "name": "RSpec - Single spec",
+      "type": "Ruby",
+      "request": "launch",
+      "cwd": "${workspaceRoot}",
+      "program": "${workspaceRoot}/bin/rspec",
+      "args": [
+        "-I",
+        "${workspaceRoot}",
+        "${file}:${lineNumber}"
+      ]
+    }
+  ]
+}

--- a/templates/dotfiles/.vscode/settings.json
+++ b/templates/dotfiles/.vscode/settings.json
@@ -2,9 +2,10 @@
   "search.exclude": {
     "**/node_modules": true
   },
-  "ruby.codeCompletion": false, // disable to let Solargraph do its job
-  "ruby.intellisense": false, // disable to let Solargraph do its job
-  "ruby.useLanguageServer": false, // disable to let Solargraph do its job
+  "_ruby_comment": "codeCompletion, intellisense and useLanguageServer are all delegated to Solargraph, so we disable them in ruby extension",
+  "ruby.codeCompletion": false,
+  "ruby.intellisense": false,
+  "ruby.useLanguageServer": false,
   "ruby.useBundler": true,
   "solargraph.useBundler": true
 }

--- a/templates/dotfiles/.vscode/settings.json
+++ b/templates/dotfiles/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "search.exclude": {
+    "**/node_modules": true
+  },
+  "ruby.codeCompletion": false, // disable to let Solargraph do its job
+  "ruby.intellisense": false, // disable to let Solargraph do its job
+  "ruby.useLanguageServer": false, // disable to let Solargraph do its job
+  "ruby.useBundler": true,
+  "solargraph.useBundler": true
+}


### PR DESCRIPTION
## Adds support to vscode workflow

### New development gems

* `debase`, `ruby-debug-ide` (version agnostic): enable the project to use debugger from https://github.com/rubyide/vscode-ruby.git plugin.
* `solargraph` (version agnostic): enables, through https://github.com/castwide/vscode-solargraph, complete intellisense

It's up to the developer to install aforementioned plugins into his IDE. Adding a small paragraph to the README about this fact.

### VSCode debugger configurations

We'll have a default `.vscode/launch.json` to have control over the integrated debugger by default. I've added a custom `RSpec - Single spec` config useful for running a single block of specs based on curson position into the editor.